### PR TITLE
Modularize cropping logic

### DIFF
--- a/Lib/PECropView.h
+++ b/Lib/PECropView.h
@@ -14,6 +14,8 @@
 
 @property (nonatomic) UIImage *image;
 @property (nonatomic, readonly) UIImage *croppedImage;
+@property (nonatomic, readonly) CGRect zoomedCropRect;
+@property (nonatomic, readonly) CGAffineTransform rotation;
 
 @property (nonatomic) BOOL keepingCropAspectRatio;
 @property (nonatomic) CGFloat cropAspectRatio;

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -8,6 +8,7 @@
 
 #import "PECropView.h"
 #import "PECropRectView.h"
+#import "UIImage+PECrop.h"
 
 static const CGFloat MarginTop = 37.0f;
 static const CGFloat MarginBottom = MarginTop;
@@ -258,6 +259,11 @@ static const CGFloat MarginRight = MarginLeft;
 
 - (UIImage *)croppedImage
 {
+    return [self.image rotatedImageWithtransform:self.rotation croppedToRect:self.zoomedCropRect];
+}
+
+- (CGRect)zoomedCropRect
+{
     CGRect cropRect = [self convertRect:self.scrollView.frame toView:self.zoomingView];
     CGSize size = self.image.size;
     
@@ -274,32 +280,12 @@ static const CGFloat MarginRight = MarginLeft;
                                        cropRect.size.width / ratio,
                                        cropRect.size.height / ratio);
     
-    UIImage *rotatedImage = [self rotatedImageWithImage:self.image transform:self.imageView.transform];
-    
-    CGImageRef croppedImage = CGImageCreateWithImageInRect(rotatedImage.CGImage, zoomedCropRect);
-    UIImage *image = [UIImage imageWithCGImage:croppedImage scale:1.0f orientation:rotatedImage.imageOrientation];
-    CGImageRelease(croppedImage);
-    
-    return image;
+    return zoomedCropRect;
 }
 
-- (UIImage *)rotatedImageWithImage:(UIImage *)image transform:(CGAffineTransform)transform
+- (CGAffineTransform)rotation
 {
-    CGSize size = image.size;
-    
-    UIGraphicsBeginImageContext(size);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    CGContextTranslateCTM(context, size.width / 2, size.height / 2);
-    CGContextConcatCTM(context, transform);
-    CGContextTranslateCTM(context, size.width / -2, size.height / -2);
-    [image drawInRect:CGRectMake(0.0f, 0.0f, size.width, size.height)];
-    
-    UIImage *rotatedImage = UIGraphicsGetImageFromCurrentImageContext();
-    
-    UIGraphicsEndImageContext();
-    
-    return rotatedImage;
+    return self.imageView.transform;
 }
 
 - (CGRect)cappedCropRectInImageRectWithCropRectView:(PECropRectView *)cropRectView

--- a/Lib/UIImage+PECrop.h
+++ b/Lib/UIImage+PECrop.h
@@ -1,0 +1,17 @@
+//
+//  UIImage+PECrop.h
+//  PhotoCropEditor
+//
+//  Created by Ernesto Rivera on 2013/07/29.
+//  Copyright (c) 2013 kishikawa katsumi. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (PECrop)
+
+- (UIImage *)rotatedImageWithtransform:(CGAffineTransform)rotation
+                         croppedToRect:(CGRect)rect;
+
+@end
+

--- a/Lib/UIImage+PECrop.m
+++ b/Lib/UIImage+PECrop.m
@@ -1,0 +1,47 @@
+//
+//  UIImage+PECrop.m
+//  PhotoCropEditor
+//
+//  Created by Ernesto Rivera on 2013/07/29.
+//  Copyright (c) 2013 kishikawa katsumi. All rights reserved.
+//
+
+#import "UIImage+PECrop.h"
+
+@implementation UIImage (PECrop)
+
+- (UIImage *)rotatedImageWithtransform:(CGAffineTransform)rotation
+                         croppedToRect:(CGRect)rect
+{
+    UIImage *rotatedImage = [self rotatedImageWithtransform:rotation];
+
+    CGImageRef croppedImage = CGImageCreateWithImageInRect(rotatedImage.CGImage, rect);
+    UIImage *image = [UIImage imageWithCGImage:croppedImage scale:self.scale orientation:rotatedImage.imageOrientation];
+    CGImageRelease(croppedImage);
+    
+    return image;
+}
+
+- (UIImage *)rotatedImageWithtransform:(CGAffineTransform)transform
+{
+    CGSize size = self.size;
+    
+    UIGraphicsBeginImageContextWithOptions(size,
+                                           YES,                     // Opaque
+                                           self.scale);             // Use image scale
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextTranslateCTM(context, size.width / 2, size.height / 2);
+    CGContextConcatCTM(context, transform);
+    CGContextTranslateCTM(context, size.width / -2, size.height / -2);
+    [self drawInRect:CGRectMake(0.0f, 0.0f, size.width, size.height)];
+    
+    UIImage *rotatedImage = UIGraphicsGetImageFromCurrentImageContext();
+    
+    UIGraphicsEndImageContext();
+    
+    return rotatedImage;
+}
+
+@end
+

--- a/PEPhotoCropEditor.xcodeproj/project.pbxproj
+++ b/PEPhotoCropEditor.xcodeproj/project.pbxproj
@@ -27,12 +27,13 @@
 		14BB4F0C174BD7B100C75F78 /* PECropViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BB4F0B174BD7B100C75F78 /* PECropViewController.m */; };
 		14BB4F11174BD7CC00C75F78 /* PECropRectView.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BB4F0E174BD7CA00C75F78 /* PECropRectView.m */; };
 		14BB4F12174BD7CC00C75F78 /* PEResizeControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BB4F10174BD7CB00C75F78 /* PEResizeControl.m */; };
+		E576407617A7889200111967 /* UIImage+PECrop.m in Sources */ = {isa = PBXBuildFile; fileRef = E576407417A7889200111967 /* UIImage+PECrop.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		14707AE6175B99D800A58D40 /* PEPhotoCropEditor.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = PEPhotoCropEditor.bundle; path = Resources/PEPhotoCropEditor.bundle; sourceTree = SOURCE_ROOT; };
-		14707AEB175B9B6E00A58D40 /* en */ = {isa = PBXFileReference; lastKnownFileType = file; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		14707AED175B9B7000A58D40 /* ja */ = {isa = PBXFileReference; lastKnownFileType = file; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		14707AEB175B9B6E00A58D40 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		14707AED175B9B7000A58D40 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		14BB4E86174BC39000C75F78 /* PEPhotoCropEditor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PEPhotoCropEditor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		14BB4E89174BC39000C75F78 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		14BB4E8B174BC39000C75F78 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -60,6 +61,8 @@
 		14BB4F0E174BD7CA00C75F78 /* PECropRectView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PECropRectView.m; path = Lib/PECropRectView.m; sourceTree = SOURCE_ROOT; };
 		14BB4F0F174BD7CB00C75F78 /* PEResizeControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PEResizeControl.h; path = Lib/PEResizeControl.h; sourceTree = SOURCE_ROOT; };
 		14BB4F10174BD7CB00C75F78 /* PEResizeControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PEResizeControl.m; path = Lib/PEResizeControl.m; sourceTree = SOURCE_ROOT; };
+		E576407417A7889200111967 /* UIImage+PECrop.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+PECrop.m"; path = "Lib/UIImage+PECrop.m"; sourceTree = SOURCE_ROOT; };
+		E576407517A7889200111967 /* UIImage+PECrop.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+PECrop.h"; path = "Lib/UIImage+PECrop.h"; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +176,8 @@
 				14BB4F0E174BD7CA00C75F78 /* PECropRectView.m */,
 				14BB4F0F174BD7CB00C75F78 /* PEResizeControl.h */,
 				14BB4F10174BD7CB00C75F78 /* PEResizeControl.m */,
+				E576407517A7889200111967 /* UIImage+PECrop.h */,
+				E576407417A7889200111967 /* UIImage+PECrop.m */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -255,6 +260,7 @@
 				14BB4F0C174BD7B100C75F78 /* PECropViewController.m in Sources */,
 				14BB4F11174BD7CC00C75F78 /* PECropRectView.m in Sources */,
 				14BB4F12174BD7CC00C75F78 /* PEResizeControl.m in Sources */,
+				E576407617A7889200111967 /* UIImage+PECrop.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Separating the view from the cropping logic allows to programmatically crop images and create non-destructive editing tools (e.g. filters + cropping) by reusing zoomedCropRect and rotation values.
