### PR TITLE
Fix aspect ratio not being kept on edge cases

### DIFF
--- a/Lib/PECropRectView.m
+++ b/Lib/PECropRectView.m
@@ -292,13 +292,15 @@
     CGFloat minWidth = CGRectGetWidth(self.leftEdgeView.bounds) + CGRectGetWidth(self.rightEdgeView.bounds);
     if (CGRectGetWidth(rect) < minWidth) {
         rect.origin.x = CGRectGetMaxX(self.frame) - minWidth;
-        rect.size.width = minWidth;
+        rect.size = CGSizeMake(minWidth,
+                               !self.fixedAspectRatio ? rect.size.height : rect.size.height * (minWidth / rect.size.width));
     }
     
     CGFloat minHeight = CGRectGetHeight(self.topEdgeView.bounds) + CGRectGetHeight(self.bottomEdgeView.bounds);
     if (CGRectGetHeight(rect) < minHeight) {
         rect.origin.y = CGRectGetMaxY(self.frame) - minHeight;
-        rect.size.height = minHeight;
+        rect.size = CGSizeMake(!self.fixedAspectRatio ? rect.size.width : rect.size.width * (minHeight / rect.size.height),
+                               minHeight);
     }
     
     return rect;

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -295,17 +295,25 @@ static const CGFloat MarginRight = MarginLeft;
     CGRect rect = [self convertRect:cropRect toView:self.scrollView];
     if (CGRectGetMinX(rect) < CGRectGetMinX(self.zoomingView.frame)) {
         cropRect.origin.x = CGRectGetMinX([self.scrollView convertRect:self.zoomingView.frame toView:self]);
-        cropRect.size.width = CGRectGetMaxX(rect);
+        CGFloat cappedWidth = CGRectGetMaxX(rect);
+        cropRect.size = CGSizeMake(cappedWidth,
+                                   !self.keepingCropAspectRatio ? cropRect.size.height : cropRect.size.height * (cappedWidth/cropRect.size.width));
     }
     if (CGRectGetMinY(rect) < CGRectGetMinY(self.zoomingView.frame)) {
         cropRect.origin.y = CGRectGetMinY([self.scrollView convertRect:self.zoomingView.frame toView:self]);
-        cropRect.size.height = CGRectGetMaxY(rect);
+        CGFloat cappedHeight =  CGRectGetMaxY(rect);
+        cropRect.size = CGSizeMake(!self.keepingCropAspectRatio ? cropRect.size.width : cropRect.size.width * (cappedHeight / cropRect.size.height),
+                                   cappedHeight);
     }
     if (CGRectGetMaxX(rect) > CGRectGetMaxX(self.zoomingView.frame)) {
-        cropRect.size.width = CGRectGetMaxX([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinX(cropRect);
+        CGFloat cappedWidth = CGRectGetMaxX([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinX(cropRect);
+        cropRect.size = CGSizeMake(cappedWidth,
+                                   !self.keepingCropAspectRatio ? cropRect.size.height : cropRect.size.height * (cappedWidth/cropRect.size.width));
     }
     if (CGRectGetMaxY(rect) > CGRectGetMaxY(self.zoomingView.frame)) {
-        cropRect.size.height = CGRectGetMaxY([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinY(cropRect);
+        CGFloat cappedHeight =  CGRectGetMaxY([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinY(cropRect);
+        cropRect.size = CGSizeMake(!self.keepingCropAspectRatio ? cropRect.size.width : cropRect.size.width * (cappedHeight / cropRect.size.height),
+                                   cappedHeight);
     }
     
     return cropRect;


### PR DESCRIPTION
In some special cases only on dimension was getting re-adjusted despite setting `keepingCropAspectRatio` to `YES`.
