### PR TITLE
New userHasModifiedCropArea property

### DIFF
--- a/Lib/PECropView.h
+++ b/Lib/PECropView.h
@@ -16,6 +16,7 @@
 @property (nonatomic, readonly) UIImage *croppedImage;
 @property (nonatomic, readonly) CGRect zoomedCropRect;
 @property (nonatomic, readonly) CGAffineTransform rotation;
+@property (nonatomic, readonly) BOOL userHasModifiedCropArea;
 
 @property (nonatomic) BOOL keepingCropAspectRatio;
 @property (nonatomic) CGFloat cropAspectRatio;

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -283,6 +283,14 @@ static const CGFloat MarginRight = MarginLeft;
     return zoomedCropRect;
 }
 
+- (BOOL)userHasModifiedCropArea
+{
+    CGRect zoomedCropRect = CGRectIntegral(self.zoomedCropRect);
+    return (!CGPointEqualToPoint(zoomedCropRect.origin, CGPointZero) ||
+            !CGSizeEqualToSize(zoomedCropRect.size, self.image.size) ||
+            !CGAffineTransformEqualToTransform(self.rotation, CGAffineTransformIdentity));
+}
+
 - (CGAffineTransform)rotation
 {
     return self.imageView.transform;


### PR DESCRIPTION
Allows to check if there is actually something to crop already.
For instance to show/hide an Apply button or to prompt user to accept/discard an unfinished crop.
