### PR TITLE
PECropView: Allow to programmatically set the rotation angle (with or without snapping to 90° angles)

### DIFF
--- a/Lib/PECropView.h
+++ b/Lib/PECropView.h
@@ -23,4 +23,7 @@
 
 @property (nonatomic) CGRect cropRect;
 
+@property (nonatomic) CGFloat rotationAngle;
+- (void)setRotationAngle:(CGFloat)rotationAngle snap:(BOOL)snap;
+
 @end

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -296,6 +296,26 @@ static const CGFloat MarginRight = MarginLeft;
     return self.imageView.transform;
 }
 
+- (CGFloat)rotationAngle
+{
+    CGAffineTransform rotation = self.imageView.transform;
+    return atan2f(rotation.b, rotation.a);
+}
+
+- (void)setRotationAngle:(CGFloat)rotationAngle
+{
+    self.imageView.transform = CGAffineTransformMakeRotation(rotationAngle);
+}
+
+- (void)setRotationAngle:(CGFloat)rotationAngle snap:(BOOL)snap
+{
+    if (snap)
+    {
+        rotationAngle = nearbyintf(rotationAngle / M_PI_2) * M_PI_2;
+    }
+    self.rotationAngle = rotationAngle;
+}
+
 - (CGRect)cappedCropRectInImageRectWithCropRectView:(PECropRectView *)cropRectView
 {
     CGRect cropRect = cropRectView.frame;
@@ -303,17 +323,25 @@ static const CGFloat MarginRight = MarginLeft;
     CGRect rect = [self convertRect:cropRect toView:self.scrollView];
     if (CGRectGetMinX(rect) < CGRectGetMinX(self.zoomingView.frame)) {
         cropRect.origin.x = CGRectGetMinX([self.scrollView convertRect:self.zoomingView.frame toView:self]);
-        cropRect.size.width = CGRectGetMaxX(rect);
+        CGFloat cappedWidth = CGRectGetMaxX(rect);
+        cropRect.size = CGSizeMake(cappedWidth,
+                                   !self.keepingCropAspectRatio ? cropRect.size.height : cropRect.size.height * (cappedWidth/cropRect.size.width));
     }
     if (CGRectGetMinY(rect) < CGRectGetMinY(self.zoomingView.frame)) {
         cropRect.origin.y = CGRectGetMinY([self.scrollView convertRect:self.zoomingView.frame toView:self]);
-        cropRect.size.height = CGRectGetMaxY(rect);
+        CGFloat cappedHeight =  CGRectGetMaxY(rect);
+        cropRect.size = CGSizeMake(!self.keepingCropAspectRatio ? cropRect.size.width : cropRect.size.width * (cappedHeight / cropRect.size.height),
+                                   cappedHeight);
     }
     if (CGRectGetMaxX(rect) > CGRectGetMaxX(self.zoomingView.frame)) {
-        cropRect.size.width = CGRectGetMaxX([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinX(cropRect);
+        CGFloat cappedWidth = CGRectGetMaxX([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinX(cropRect);
+        cropRect.size = CGSizeMake(cappedWidth,
+                                   !self.keepingCropAspectRatio ? cropRect.size.height : cropRect.size.height * (cappedWidth/cropRect.size.width));
     }
     if (CGRectGetMaxY(rect) > CGRectGetMaxY(self.zoomingView.frame)) {
-        cropRect.size.height = CGRectGetMaxY([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinY(cropRect);
+        CGFloat cappedHeight =  CGRectGetMaxY([self.scrollView convertRect:self.zoomingView.frame toView:self]) - CGRectGetMinY(cropRect);
+        cropRect.size = CGSizeMake(!self.keepingCropAspectRatio ? cropRect.size.width : cropRect.size.width * (cappedHeight / cropRect.size.height),
+                                   cappedHeight);
     }
     
     return cropRect;


### PR DESCRIPTION
This methods allow to easily implement clockwise/counter clockwise rotations from IBAction methods.

``` objective-c
- (IBAction)rotationButtonTapped:(id)sender
{
    [_cropView setRotationAngle:_cropView.rotationAngle + M_PI_2
                           snap:YES];
}
```
