### PR TITLE
PECropView: Ignore hit tests when user interaction is disabled

### DIFF
--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -103,6 +103,10 @@ static const CGFloat MarginRight = MarginLeft;
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
+    if (!self.userInteractionEnabled) {
+        return nil;
+    }
+    
     UIView *hitView = [self.cropRectView hitTest:[self convertPoint:point toView:self.cropRectView] withEvent:event];
     if (hitView) {
         return hitView;


### PR DESCRIPTION
The current implementation of `hitTest:withEvent:` was preventing correctly disabling user interaction from the crop view and its subviews.

We're using this library extensively now. Sorry for the pull requests' spam!
