### PR TITLE
supports iOS7 translucent navigation bar

### DIFF
--- a/DemoApp/ViewController.m
+++ b/DemoApp/ViewController.m
@@ -24,6 +24,12 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
+        self.edgesForExtendedLayout = UIRectEdgeNone;
+    }
+#endif
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -50,6 +50,12 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
 {
     [super viewDidLoad];
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
+        self.edgesForExtendedLayout = UIRectEdgeNone;
+    }
+#endif
+
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                           target:self
                                                                                           action:@selector(cancel:)];


### PR DESCRIPTION
iOS7 has translucent navigation bar which causes the cropping edge cursor hidden under the navigation bar above.
This patch works on iOS7 and be skipped on iOS6.
Tested on Xcode 4.6.3 and Xcode 5.
Thank you for the great library anyway.
