### PR TITLE
Fix layout of editor view on iOS 7

### DIFF
--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -72,7 +72,9 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
                                                                        action:@selector(constrain:)];
     self.toolbarItems = @[flexibleSpace, constrainButton, flexibleSpace];
     self.navigationController.toolbarHidden = NO;
-    
+    self.navigationController.navigationBar.translucent = NO;
+    self.navigationController.toolbar.translucent = NO;
+
     self.cropView.image = self.image;
 }
 


### PR DESCRIPTION
This bug was reported in #9: on iOS 7, the editor view extends below the navigation and tool bars. This is particularly problematic for tall, narrow images, as the crop handles at the top are hidden behind the navigation bar:

![ios simulator-1](https://f.cloud.github.com/assets/163838/1829946/30c10c2e-7312-11e3-8722-b94459417f61.png)

Disabling translucence on the two bars constraints the view within them, so that it displays correctly.

I tested this in the simulator for iOS 6.1 and didn't get any errors. I'm not too familiar with the inner workings here, but I guess Objective-C just ignores the property set if that property doesn't exist?
