### PR TITLE
Crop view: prevent the navigation bar and toolbar from blinking

### DIFF
--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -54,6 +54,8 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
     if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
         self.edgesForExtendedLayout = UIRectEdgeNone;
     }
+    self.navigationController.navigationBar.translucent = NO;
+    self.navigationController.toolbar.translucent = NO;
 #endif
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel


### PR DESCRIPTION
I wasn't sure if I'd be able to catch this in a gif, but if you watch closely, you can see the navigation bar and toolbar blink once the view has finished loading.

![blink](https://f.cloud.github.com/assets/163838/1955458/675f51ec-81e9-11e3-865a-1762d3c1464b.gif)

d88714f17fbac38db39d8dac723bd9f2698efc75 Fixed the rect for this view, but this blink thing can be prevented by the disabling the translucence (as I originally proposed in #25).
