### PR TITLE
Only set the toolbar items if they haven't been specified

### DIFF
--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -62,15 +62,17 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                            target:self
                                                                                            action:@selector(done:)];
-    
-    UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
-                                                                                   target:nil
-                                                                                   action:nil];
-    UIBarButtonItem *constrainButton = [[UIBarButtonItem alloc] initWithTitle:PELocalizedString(@"Constrain", nil)
-                                                                        style:UIBarButtonItemStyleBordered
-                                                                       target:self
-                                                                       action:@selector(constrain:)];
-    self.toolbarItems = @[flexibleSpace, constrainButton, flexibleSpace];
+
+    if (!self.toolbarItems) {
+        UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
+                                                                                       target:nil
+                                                                                       action:nil];
+        UIBarButtonItem *constrainButton = [[UIBarButtonItem alloc] initWithTitle:PELocalizedString(@"Constrain", nil)
+                                                                            style:UIBarButtonItemStyleBordered
+                                                                           target:self
+                                                                           action:@selector(constrain:)];
+        self.toolbarItems = @[flexibleSpace, constrainButton, flexibleSpace];
+    }
     self.navigationController.toolbarHidden = NO;
     
     self.cropView.image = self.image;


### PR DESCRIPTION
The `viewDidLoad` method on `PECropViewController` adds the Constrain button to the toolbar. Since this happens right when the view loads, there isn't any way to override it, either to remove the Constrain button or replace it with others.

This change just wraps the `toolbarItems` set in a conditional, so that `toolbarItems` is only changed if it's not already set. In most cases, the Constrain button is shown as it always has been, but now one has the option of setting `toolbarItems` on the controller when it's created.

For example, in the demo app `ViewController.m`, you can now do this (the last line was added):

``` objc
- (IBAction)openEditor:(id)sender
{
    PECropViewController *controller = [[PECropViewController alloc] init];
    controller.delegate = self;
    controller.image = self.imageView.image;
    // Don't show the Constrain (or any other) toolbar button
    controller.toolbarItems = @[];

    // Other logic…
}
```

One can also specify other toolbar buttons here if desired.
