### PR TITLE
Added the ability to hide toolbar

### DIFF
--- a/Lib/PECropViewController.h
+++ b/Lib/PECropViewController.h
@@ -20,6 +20,7 @@
 
 @property (nonatomic) CGRect cropRect;
 
+@property (nonatomic) BOOL toolbarHidden;
 @end
 
 @protocol PECropViewControllerDelegate <NSObject>

--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -70,7 +70,7 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
                                                                            action:@selector(constrain:)];
         self.toolbarItems = @[flexibleSpace, constrainButton, flexibleSpace];
     }
-    self.navigationController.toolbarHidden = NO;
+    self.navigationController.toolbarHidden = self.toolbarHidden;
     
     self.cropView.image = self.image;
 }


### PR DESCRIPTION
Sometimes the constraint button is not really necessary and this commit provides an easy way to hide the toolbar by calling -[PECropViewController setToolbarHidden:(BOOL)] method.
