### PR TITLE
Fixed crashes on resize with keepingCropAspectRatio and cropAspectRatio

### DIFF
--- a/Lib/PECropRectView.m
+++ b/Lib/PECropRectView.m
@@ -290,20 +290,24 @@
             }
         }
     }
-    
+
+    CGRect constrainedRect = rect;
+
     CGFloat minWidth = CGRectGetWidth(self.leftEdgeView.bounds) + CGRectGetWidth(self.rightEdgeView.bounds);
     if (CGRectGetWidth(rect) < minWidth) {
-        rect.origin.x = CGRectGetMaxX(self.frame) - minWidth;
-        rect.size = CGSizeMake(minWidth,
+        constrainedRect.origin.x = CGRectGetMaxX(self.frame) - minWidth;
+        constrainedRect.size = CGSizeMake(minWidth,
                                !self.fixedAspectRatio ? rect.size.height : rect.size.height * (minWidth / rect.size.width));
     }
     
     CGFloat minHeight = CGRectGetHeight(self.topEdgeView.bounds) + CGRectGetHeight(self.bottomEdgeView.bounds);
     if (CGRectGetHeight(rect) < minHeight) {
-        rect.origin.y = CGRectGetMaxY(self.frame) - minHeight;
-        rect.size = CGSizeMake(!self.fixedAspectRatio ? rect.size.width : rect.size.width * (minHeight / rect.size.height),
+        constrainedRect.origin.y = CGRectGetMaxY(self.frame) - minHeight;
+        constrainedRect.size = CGSizeMake(!self.fixedAspectRatio ? rect.size.width : rect.size.width * (minHeight / rect.size.height),
                                minHeight);
     }
+
+    rect = constrainedRect;
     
     return rect;
 }


### PR DESCRIPTION
# Problem

Caused crash when crop area moved left bottom or right bottom corners with below settings.

``` objc
PECropViewController *controller = [[PECropViewController alloc] init];
controller.toolbarHidden = YES;
controller.cropAspectRatio = 1.0;
controller.keepingCropAspectRatio = YES;
```

This crash caused by NaN value insert into view frame.

![ios mar 6 2014 5 06 33 pm](https://f.cloud.github.com/assets/113420/2343026/4be5a2d2-a506-11e3-82fa-e9967b29094e.png)
# Solution

In keepingCropAspectRatio = YES condition, constrained minWidth result effected minHeight result. I solved by remove this dependency.
