### PR TITLE
Delete warning

### DIFF
--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -11,9 +11,9 @@
 #import "UIImage+PECrop.h"
 
 static const CGFloat MarginTop = 37.0f;
-static const CGFloat MarginBottom = MarginTop;
+//static const CGFloat MarginBottom = MarginTop;
 static const CGFloat MarginLeft = 20.0f;
-static const CGFloat MarginRight = MarginLeft;
+//static const CGFloat MarginRight = MarginLeft;
 
 @interface PECropView () <UIScrollViewDelegate, UIGestureRecognizerDelegate, PECropRectViewDelegate>
 

--- a/PEPhotoCropEditor.podspec
+++ b/PEPhotoCropEditor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "PEPhotoCropEditor"
-  s.version               = "1.3.1"
+  s.version               = "1.3.2"
   s.summary               = "Image cropping library for iOS, similar to the Photos.app UI."
   s.homepage              = "https://github.com/kishikawakatsumi/PEPhotoCropEditor"
   s.social_media_url      = "https://twitter.com/k_katsumi"


### PR DESCRIPTION
delete warning for unused vars.
Upgrade podSpec for version

Answer to this : 
https://github.com/kishikawakatsumi/PEPhotoCropEditor/issues/45
