### PR TITLE
Useful properties to enable/disable rotation and access to crop/transform values

### DIFF
--- a/Lib/PECropView.h
+++ b/Lib/PECropView.h
@@ -26,6 +26,8 @@
 
 @property (nonatomic) CGFloat rotationAngle;
 
+@property (nonatomic, weak, readonly) UIRotationGestureRecognizer *rotationGestureRecognizer;
+
 - (void)resetCropRect;
 - (void)resetCropRectAnimated:(BOOL)animated;
 

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -76,6 +76,7 @@ static const CGFloat MarginRight = MarginLeft;
     
     UIRotationGestureRecognizer *rotationGestureRecognizer = [[UIRotationGestureRecognizer alloc] initWithTarget:self action:@selector(handleRotation:)];
     rotationGestureRecognizer.delegate = self;
+    _rotationGestureRecognizer = rotationGestureRecognizer;
     [self.scrollView addGestureRecognizer:rotationGestureRecognizer];
     
     self.cropRectView = [[PECropRectView alloc] init];

--- a/Lib/PECropViewController.h
+++ b/Lib/PECropViewController.h
@@ -23,6 +23,13 @@
 
 @property (nonatomic) BOOL toolbarHidden;
 
+@property (nonatomic, assign, getter = isRotationEnabled) BOOL rotationEnabled;
+
+@property (nonatomic, readonly) CGAffineTransform rotationTransform;
+
+@property (nonatomic, readonly) CGRect zoomedCropRect;
+
+
 - (void)resetCropRect;
 - (void)resetCropRectAnimated:(BOOL)animated;
 

--- a/Lib/PECropViewController.m
+++ b/Lib/PECropViewController.m
@@ -14,9 +14,12 @@
 @property (nonatomic) PECropView *cropView;
 @property (nonatomic) UIActionSheet *actionSheet;
 
+- (void)commonInit;
+
 @end
 
 @implementation PECropViewController
+@synthesize rotationEnabled = _rotationEnabled;
 
 + (NSBundle *)bundle
 {
@@ -33,6 +36,31 @@
 static inline NSString *PELocalizedString(NSString *key, NSString *comment)
 {
     return [[PECropViewController bundle] localizedStringForKey:key value:nil table:@"Localizable"];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    
+    if (self) {
+        [self commonInit];
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    
+    if (self) {
+        [self commonInit];
+    }
+    
+    return self;
+}
+
+- (void)commonInit {
+    self.rotationEnabled = YES;
 }
 
 #pragma mark -
@@ -75,6 +103,8 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
     self.navigationController.toolbarHidden = self.toolbarHidden;
     
     self.cropView.image = self.image;
+    
+    self.cropView.rotationGestureRecognizer.enabled = _rotationEnabled;
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -140,6 +170,27 @@ static inline NSString *PELocalizedString(NSString *key, NSString *comment)
     _cropRect = CGRectZero;
     
     self.cropView.imageCropRect = imageCropRect;
+}
+
+- (BOOL)isRotationEnabled
+{
+    return _rotationEnabled;
+}
+
+- (void)setRotationEnabled:(BOOL)rotationEnabled
+{
+    _rotationEnabled = rotationEnabled;
+    self.cropView.rotationGestureRecognizer.enabled = _rotationEnabled;
+}
+
+- (CGAffineTransform)rotationTransform
+{
+    return self.cropView.rotation;
+}
+
+- (CGRect)zoomedCropRect
+{
+    return self.cropView.zoomedCropRect;
 }
 
 - (void)resetCropRect


### PR DESCRIPTION
Thanks for the nice library. I've just added a few properties to allow to enable/disable rotation gesture and to give readonly access to transform and cropping rect values.

This should fix #56.
