### PR TITLE
UIImage+PECrop - pe_rotatedImageWithtransform releases CGContextRef when done

### DIFF
--- a/Lib/UIImage+PECrop.m
+++ b/Lib/UIImage+PECrop.m
@@ -42,6 +42,7 @@
     UIImage *rotatedImage = UIGraphicsGetImageFromCurrentImageContext();
     
     UIGraphicsEndImageContext();
+    CGContextRelease(context);
     
     return rotatedImage;
 }


### PR DESCRIPTION
So I noticed that something coming from this library was eating my memory (couldn't crop more than 5 photos without running out of RAM). After digging into instruments, I found the un-released allocation.

![image](https://cloud.githubusercontent.com/assets/169076/3422733/4209c15a-ff5e-11e3-810b-396448d05713.png)

Looks like we just need to release the CGContextRef when we're done.
