### PR TITLE
Memory optimization for big image if rotation disabled

### DIFF
--- a/Lib/UIImage+PECrop.m
+++ b/Lib/UIImage+PECrop.m
@@ -13,8 +13,11 @@
 - (UIImage *)rotatedImageWithtransform:(CGAffineTransform)rotation
                          croppedToRect:(CGRect)rect
 {
-    UIImage *rotatedImage = [self pe_rotatedImageWithtransform:rotation];
-    
+    UIImage *rotatedImage = self;
+    if (!CGAffineTransformIsIdentity(rotation)) {
+        rotatedImage = [self pe_rotatedImageWithtransform:rotation];
+    }
+
     CGFloat scale = rotatedImage.scale;
     CGRect cropRect = CGRectApplyAffineTransform(rect, CGAffineTransformMakeScale(scale, scale));
     


### PR DESCRIPTION
pe_rotatedImageWithtransform will consume much Memory
if original image is large.

if not rotation, pe_rotatedImageWithtransform are not needed.
