### PR TITLE
remove memory usage spike for images that are not rotated

### DIFF
--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -320,8 +320,11 @@ static const CGFloat MarginLeft = 20.0f;
 
 - (UIImage *)croppedImage
 {
-    BOOL isNotTransformed = CGAffineTransformEqualToTransform(self.rotation, CGAffineTransformIdentity);
-    return isNotTransformed ? self.image : [self.image rotatedImageWithtransform:self.rotation croppedToRect:self.zoomedCropRect];
+    if (CGAffineTransformEqualToTransform(self.rotation, CGAffineTransformIdentity)) {
+        return [self.image pe_croppedImageWithRect:self.zoomedCropRect];
+    } else {
+        return [self.image rotatedImageWithtransform:self.rotation croppedToRect:self.zoomedCropRect];
+    }
 }
 
 - (CGRect)zoomedCropRect

--- a/Lib/PECropView.m
+++ b/Lib/PECropView.m
@@ -320,7 +320,8 @@ static const CGFloat MarginLeft = 20.0f;
 
 - (UIImage *)croppedImage
 {
-    return [self.image rotatedImageWithtransform:self.rotation croppedToRect:self.zoomedCropRect];
+    BOOL isNotTransformed = CGAffineTransformEqualToTransform(self.rotation, CGAffineTransformIdentity);
+    return isNotTransformed ? self.image : [self.image rotatedImageWithtransform:self.rotation croppedToRect:self.zoomedCropRect];
 }
 
 - (CGRect)zoomedCropRect

--- a/Lib/UIImage+PECrop.h
+++ b/Lib/UIImage+PECrop.h
@@ -13,4 +13,6 @@
 - (UIImage *)rotatedImageWithtransform:(CGAffineTransform)rotation
                          croppedToRect:(CGRect)rect;
 
+- (UIImage *)pe_croppedImageWithRect:(CGRect)rect;
+
 @end

--- a/Lib/UIImage+PECrop.m
+++ b/Lib/UIImage+PECrop.m
@@ -14,12 +14,26 @@
                          croppedToRect:(CGRect)rect
 {
     UIImage *rotatedImage = [self pe_rotatedImageWithtransform:rotation];
+    UIImage *croppedImage = [rotatedImage pe_croppedImageWithRect:rect preferredScale:self.scale];
     
-    CGFloat scale = rotatedImage.scale;
+    return croppedImage;
+}
+
+- (UIImage *)pe_croppedImageWithRect:(CGRect)rect
+{
+    return [self pe_croppedImageWithRect:rect preferredScale:self.scale];
+}
+
+#pragma mark - private methods and helpers
+
+- (UIImage *)pe_croppedImageWithRect:(CGRect)rect
+                      preferredScale:(CGFloat)preferredScale
+{
+    CGFloat scale = self.scale;
     CGRect cropRect = CGRectApplyAffineTransform(rect, CGAffineTransformMakeScale(scale, scale));
     
-    CGImageRef croppedImage = CGImageCreateWithImageInRect(rotatedImage.CGImage, cropRect);
-    UIImage *image = [UIImage imageWithCGImage:croppedImage scale:self.scale orientation:rotatedImage.imageOrientation];
+    CGImageRef croppedImage = CGImageCreateWithImageInRect(self.CGImage, cropRect);
+    UIImage *image = [UIImage imageWithCGImage:croppedImage scale:preferredScale orientation:self.imageOrientation];
     CGImageRelease(croppedImage);
     
     return image;

--- a/PEPhotoCropEditor.podspec
+++ b/PEPhotoCropEditor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "PEPhotoCropEditor"
-  s.version               = "1.3.2"
+  s.version               = "1.3.3"
   s.summary               = "Image cropping library for iOS, similar to the Photos.app UI."
   s.homepage              = "https://github.com/kishikawakatsumi/PEPhotoCropEditor"
   s.social_media_url      = "https://twitter.com/k_katsumi"

--- a/PEPhotoCropEditor.podspec
+++ b/PEPhotoCropEditor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                  = "PEPhotoCropEditor"
-  s.version               = "1.3.3"
+  s.version               = "1.3.4"
   s.summary               = "Image cropping library for iOS, similar to the Photos.app UI."
   s.homepage              = "https://github.com/kishikawakatsumi/PEPhotoCropEditor"
   s.social_media_url      = "https://twitter.com/k_katsumi"


### PR DESCRIPTION
Hello,
thank you for sharing your library, it works great.

During working PEPhotoCropEditor I've noticed a memory spike after accepting cropped image. This can be reduced in a simple way if the image is not rotated. For photo taken with iPhone 6 this would save around 30 MB of RAM.

![pecrop_instruments](https://cloud.githubusercontent.com/assets/830743/7588271/5306b0fa-f8bc-11e4-9221-b48f4674b64f.png)
