### PR TITLE
add photoLibrary & camera description

### DIFF
--- a/DemoApp/PEPhotoCropEditor-Info.plist
+++ b/DemoApp/PEPhotoCropEditor-Info.plist
@@ -45,5 +45,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>photoLibraryDescription</string>
+	<key>NSCameraUsageDescription</key>
+	<string>cameraDescription</string>
 </dict>
 </plist>

--- a/PEPhotoCropEditor.xcodeproj/project.pbxproj
+++ b/PEPhotoCropEditor.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		14BB4EAD174BC39000C75F78 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DemoApp/PEPhotoCropEditor-Prefix.pch";
 				INFOPLIST_FILE = "DemoApp/PEPhotoCropEditor-Info.plist";
@@ -376,6 +377,7 @@
 		14BB4EAE174BC39000C75F78 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DemoApp/PEPhotoCropEditor-Prefix.pch";
 				INFOPLIST_FILE = "DemoApp/PEPhotoCropEditor-Info.plist";


### PR DESCRIPTION
it's necessary that NSPhotoLibraryUsageDescription & NSCameraUsageDescription will be added to info.plist to use photo library and camera.